### PR TITLE
Invoke hbase instead of ruby as jruby is required for the check

### DIFF
--- a/bin/check-hbase-regions.rb
+++ b/bin/check-hbase-regions.rb
@@ -1,4 +1,4 @@
-#! /usr/bin/env ruby
+#!/usr/bin/hbase org.jruby.Main
 #
 #   check-hbase-regions
 #

--- a/bin/check-hbase-regions.rb
+++ b/bin/check-hbase-regions.rb
@@ -27,7 +27,6 @@
 #   Released under the same terms as Sensu (the MIT license); see LICENSE
 #   for details.
 #
-
 require 'java'
 require 'pp'
 
@@ -79,8 +78,9 @@ def regionserver_info
 
   status = admin.getClusterStatus
   status.getServerInfo.map do |server|
-    { hostname: server.getServerAddress.getHostname,
-      regions: server.getLoad.getNumberOfRegions
+    {
+      :hostname => server.getServerAddress.getHostname,
+      :regions => server.getLoad.getNumberOfRegions
     }
   end
 end
@@ -88,15 +88,15 @@ end
 def check_threshold(info)
   case info[:regions]
   when config[:ok]..config[:warning]
-    { status: :ok, msg: "Regions: #{info.inspect}" }
+    { :status => :ok, :msg => "Regions: #{info.inspect}" }
   when config[:warning]..config[:critical]
-    { status: :warning, msg: "Regions: #{info.inspect}" }
+    { :status => :warning, :msg => "Regions: #{info.inspect}" }
   else
-    { status: :critical, msg: "Regions: #{info.inspect}" }
+    { :status => :critical, :msg => "Regions: #{info.inspect}" }
   end
 end
 
-@config = { ok: 0, warning: 900, critical: 1000 }
+@config = { :ok => 0, :warning => 900, :critical => 1000 }
 
 class Array
   def second

--- a/bin/check-hbase-status.rb
+++ b/bin/check-hbase-status.rb
@@ -1,4 +1,4 @@
-#! /usr/bin/env ruby
+#!/usr/bin/hbase org.jruby.Main
 #
 #   check-hbase-status
 #


### PR DESCRIPTION
This is largely broken.
- Need to invoke hbase instead of ruby
- Need to use 1.8 syntax due to jruby version bundled with hbase

Looks like it was broken from upstream upon rubocop etc. fixes.
